### PR TITLE
Bugfix/account-id

### DIFF
--- a/ap/aws/glue.py
+++ b/ap/aws/glue.py
@@ -1,5 +1,3 @@
-from django.conf import settings
-
 from . import base
 
 
@@ -8,23 +6,28 @@ class GlueService(base.AWSService):
 
     def __init__(self, catalog_id=None):
         super().__init__()
-        self.catalog_id = catalog_id or settings.GLUE_CATALOG_ID
+        self.catalog_id = catalog_id or self.account_id
 
-    def get_database_list(self):
-        databases = self._request("get_databases")
+    def get_database_list(self, catalog_id=None):
+        databases = self._request("get_databases", CatalogId=catalog_id or self.catalog_id)
         if not databases:
             return []
         return databases["DatabaseList"]
 
-    def get_table_list(self, database_name):
-        tables = self._request("get_tables", CatalogId=self.catalog_id, DatabaseName=database_name)
+    def get_table_list(self, database_name, catalog_id=None):
+        tables = self._request(
+            "get_tables", CatalogId=catalog_id or self.catalog_id, DatabaseName=database_name
+        )
         if not tables:
             return []
         return tables["TableList"]
 
-    def get_table_detail(self, database_name, table_name):
+    def get_table_detail(self, database_name, table_name, catalog_id=None):
         table = self._request(
-            "get_table", CatalogId=self.catalog_id, DatabaseName=database_name, Name=table_name
+            "get_table",
+            CatalogId=catalog_id or self.catalog_id,
+            DatabaseName=database_name,
+            Name=table_name,
         )
         if not table:
             return {}

--- a/ap/aws/quicksight.py
+++ b/ap/aws/quicksight.py
@@ -7,10 +7,11 @@ class QuicksightService(base.AWSService):
     aws_service_name = "quicksight"
 
     def get_embed_url(self, user):
+        user_arn = self.arn(resource=f"user/default/{user.email}")
         response = self._request(
             "generate_embed_url_for_registered_user",
-            AwsAccountId=settings.COMPUTE_ACCOUNT_ID,
-            UserArn=user.quicksight_arn,
+            AwsAccountId=self.account_id,
+            UserArn=user_arn,
             ExperienceConfiguration={
                 "QuickSightConsole": {
                     "InitialPath": "/start",

--- a/ap/settings/common.py
+++ b/ap/settings/common.py
@@ -247,7 +247,6 @@ AUTHLIB_OAUTH_CLIENTS = {
             "response_type": "code",
             "token_endpoint_auth_method": "none",
             "code_challenge_method": AZURE_CODE_CHALLENGE_METHOD,
-            "prompt": "login",
         },
     },
 }

--- a/ap/settings/common.py
+++ b/ap/settings/common.py
@@ -308,7 +308,6 @@ structlog.configure(
     cache_logger_on_first_use=True,
 )
 
-COMPUTE_ACCOUNT_ID = os.environ.get("COMPUTE_ACCOUNT_ID")
 
 GLUE_CATALOG_ID = os.environ.get("GLUE_CATALOG_ID")
 
@@ -316,7 +315,6 @@ GLUE_CATALOG_ID = os.environ.get("GLUE_CATALOG_ID")
 IDENTITY_CENTRE_OIDC_ARN = os.environ.get("IDENTITY_CENTRE_OIDC_ARN")
 # role to assume when requesting temporary credentials with the users Identity Center context
 IAM_BEARER_ROLE_ARN = os.environ.get("IAM_BEARER_ROLE_ARN")
-COMPUTE_ACCOUNT_ID = os.environ.get("COMPUTE_ACCOUNT_ID")
 
 QUICKSIGHT_DOMAINS = os.environ.get("QUICKSIGHT_DOMAINS", "").split(",")
 

--- a/ap/users/models.py
+++ b/ap/users/models.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.contrib.auth.models import AbstractUser
 from django.db import models
 
@@ -22,12 +21,6 @@ class User(AbstractUser):
     @staticmethod
     def construct_username(name):
         return sanitize_dns_label(name)
-
-    @property
-    def quicksight_arn(self):
-        return (
-            f"arn:aws:quicksight:eu-west-2:{settings.COMPUTE_ACCOUNT_ID}:user/default/{self.email}"
-        )
 
     @property
     def display_first_name(self):

--- a/ap/views.py
+++ b/ap/views.py
@@ -6,6 +6,11 @@ from django.views.generic import TemplateView
 class IndexView(TemplateView):
     template_name = "home.html"
 
+    def get_template_names(self) -> list[str]:
+        if not self.request.user.is_authenticated:
+            self.template_name = "login.html"
+        return super().get_template_names()
+
 
 class HealthcheckView(View):
     def get(self, request):

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: analytical-platform-ui
 description: Analytical Platform UI
 type: application
-version: 0.1.1
-appVersion: 0.1.1
+version: 0.1.2
+appVersion: 0.1.2
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/4/4a/Ministry_of_Justice_logo_%28United_Kingdom%29.svg/611px-Ministry_of_Justice_logo_%28United_Kingdom%29.svg.png
 maintainers:
   - name: moj-data-platform-robot

--- a/templates/home.html
+++ b/templates/home.html
@@ -4,29 +4,21 @@
 
 {% block content %}
 
-    {% if not request.user.is_authenticated %}
-        <div class="govuk-width-container">
-            <h1 class="govuk-heading-xl">Analytical Platform Dashboard</h1>
-            <p class="govuk-body">The Analytical Platform provides users with a place to store, ingest, consume and visualise data.</p>
-            <a class="govuk-button govuk-button--start" href="{% url 'login' %}">Sign in</a>
-        </div>
-    {% else %}
-        <div class="govuk-width-container">
-            <h1 class="govuk-heading-l">Welcome {{ user.display_first_name }}</h1>
-            <p class="govuk-body">The Analytical Platform provides users with a place to store, ingest, consume and visualise data.</p>
-        </div>
+    <div class="govuk-width-container">
+        <h1 class="govuk-heading-l">Welcome {{ user.display_first_name }}</h1>
+        <p class="govuk-body">The Analytical Platform provides users with a place to store, ingest, consume and visualise data.</p>
+    </div>
 
-        <div class="govuk-width-container">
-            <h2 class="govuk-heading-l">Tools and services</h2>
-            <ul class="govuk-list">
-                <li>
-                    <a href="{% url 'quicksight:index' %}">Visualise data with QuickSight</a>
-                </li>
-                <li>
-                    <a href="{% url 'database_access:list' %}">Database access</a>
-                </li>
-            </ul>
-        </div>
-    {% endif %}
+    <div class="govuk-width-container">
+        <h2 class="govuk-heading-l">Tools and services</h2>
+        <ul class="govuk-list">
+            <li>
+                <a href="{% url 'quicksight:index' %}">Visualise data with QuickSight</a>
+            </li>
+            <li>
+                <a href="{% url 'database_access:list' %}">Database access</a>
+            </li>
+        </ul>
+    </div>
 
 {% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+
+{% extends "base.html" %}
+
+{% block content %}
+
+    <div class="govuk-width-container">
+        <h1 class="govuk-heading-xl">Analytical Platform Dashboard</h1>
+        <p class="govuk-body">The Analytical Platform provides users with a place to store, ingest, consume and visualise data.</p>
+        <a class="govuk-button govuk-button--start" href="{% url 'login' %}">Sign in</a>
+    </div>
+
+{% endblock %}


### PR DESCRIPTION
Fixes bugs discovered after previous deployment, namely:
- Error when attempting to load QuickSight as AWS account ID was missing
- No databases returned as missing catalog ID
- Bug loading homepage when ID token had expired