### PR TITLE
Bugfix/allowed hosts

### DIFF
--- a/ap/settings/common.py
+++ b/ap/settings/common.py
@@ -210,8 +210,6 @@ LOGOUT_REDIRECT_URL = "/"
 # Whitelist values for the HTTP Host header, to prevent certain attacks
 ALLOWED_HOSTS = [host for host in os.environ.get("ALLOWED_HOSTS", "").split() if host]
 
-QUICKSIGHT_DOMAINS = [f"https://{host}" for host in ALLOWED_HOSTS] or ["http://localhost:8000"]
-
 # -- HTTP headers
 # Sets the X-Content-Type-Options: nosniff header
 SECURE_CONTENT_TYPE_NOSNIFF = True
@@ -315,7 +313,7 @@ IDENTITY_CENTRE_OIDC_ARN = os.environ.get("IDENTITY_CENTRE_OIDC_ARN")
 # role to assume when requesting temporary credentials with the users Identity Center context
 IAM_BEARER_ROLE_ARN = os.environ.get("IAM_BEARER_ROLE_ARN")
 
-QUICKSIGHT_DOMAINS = os.environ.get("QUICKSIGHT_DOMAINS", "").split(",")
+QUICKSIGHT_DOMAINS = [f"https://{host}" for host in ALLOWED_HOSTS] or ["http://localhost:8000"]
 
 # should not be required when using a service role e.g. in dev/prod
 DEFAULT_STS_ROLE_TO_ASSUME = os.environ.get("DEFAULT_STS_ROLE_TO_ASSUME", None)

--- a/ap/settings/common.py
+++ b/ap/settings/common.py
@@ -207,10 +207,10 @@ LOGIN_URL = "login"
 
 LOGOUT_REDIRECT_URL = "/"
 
-ALLOWED_HOSTS: list = []
-
 # Whitelist values for the HTTP Host header, to prevent certain attacks
 ALLOWED_HOSTS = [host for host in os.environ.get("ALLOWED_HOSTS", "").split() if host]
+
+QUICKSIGHT_DOMAINS = [f"https://{host}" for host in ALLOWED_HOSTS] or ["http://localhost:8000"]
 
 # -- HTTP headers
 # Sets the X-Content-Type-Options: nosniff header

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: analytical-platform-ui
 description: Analytical Platform UI
 type: application
-version: 0.1.2
-appVersion: 0.1.2
+version: 0.1.3
+appVersion: 0.1.3
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/4/4a/Ministry_of_Justice_logo_%28United_Kingdom%29.svg/611px-Ministry_of_Justice_logo_%28United_Kingdom%29.svg.png
 maintainers:
   - name: moj-data-platform-robot

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -54,7 +54,7 @@ app:
     - name: DJANGO_SETTINGS_MODULE
       value: ap.settings
     - name: ALLOWED_HOSTS
-      value: "*"
+      value: "*.analytical-platform.service.justice.gov.uk"
     - name: DB_USER
       valueFrom:
         secretKeyRef:


### PR DESCRIPTION
Update the `ALLOWED_HOSTS` and use these when setting quicksight domains.

When running locally, ALLOWED_HOSTS should not be set, so use `http://localhost:8000` as the domain.