### PR TITLE
Bugfix/refresh session

### DIFF
--- a/ap/auth/views/mixins.py
+++ b/ap/auth/views/mixins.py
@@ -12,5 +12,6 @@ class OIDCLoginRequiredMixin(LoginRequiredMixin):
         if not request.user.is_authenticated:
             return redirect(reverse("login"))
         if OIDCSessionValidator(request).expired():
+            request.session["next"] = request.get_full_path()
             return redirect(reverse("login"))
         return super().dispatch(request, *args, **kwargs)

--- a/ap/auth/views/views.py
+++ b/ap/auth/views/views.py
@@ -58,7 +58,8 @@ class OIDCAuthenticationView(View):
                 return self._login_failure()
             else:
                 self._login_success(request, user, token)
-                return redirect("/")
+                redirect_url = request.session.pop("next", "/")
+                return redirect(redirect_url)
         except OAuthError as error:
             if settings.DEBUG:
                 raise error

--- a/ap/views.py
+++ b/ap/views.py
@@ -1,10 +1,22 @@
 from django.http import HttpResponse
+from django.shortcuts import redirect
+from django.urls import reverse
 from django.views import View
 from django.views.generic import TemplateView
+
+from ap.auth.oidc import OIDCSessionValidator
 
 
 class IndexView(TemplateView):
     template_name = "home.html"
+
+    def dispatch(self, request, *args, **kwargs):
+        """
+        If the session has expired, redirect to login
+        """
+        if OIDCSessionValidator(request).expired():
+            return redirect(reverse("login"))
+        return super().dispatch(request, *args, **kwargs)
 
     def get_template_names(self) -> list[str]:
         if not self.request.user.is_authenticated:

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: analytical-platform-ui
 description: Analytical Platform UI
 type: application
-version: 0.1.5
-appVersion: 0.1.5
+version: 0.1.6
+appVersion: 0.1.6
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/4/4a/Ministry_of_Justice_logo_%28United_Kingdom%29.svg/611px-Ministry_of_Justice_logo_%28United_Kingdom%29.svg.png
 maintainers:
   - name: moj-data-platform-robot


### PR DESCRIPTION
When users auth/ID token expires, we silently refresh their session. However there was a bug that meant that the user would always be redirected to the homepage when their session refreshed.

This fixes the bug, by storing a "next" url in the session when it expires, and redirecting the user there if it is present.