### PR TITLE
Handle exceptions when updating LF opt-ins

### DIFF
--- a/ap/database_access/views.py
+++ b/ap/database_access/views.py
@@ -169,6 +169,15 @@ class TableAccessMixin(SingleObjectMixin):
             form.add_error(None, "An error occured granting permissions")
             return self.form_invalid(form)
 
+    def get_success_url(self) -> str:
+        return reverse(
+            "database_access:table_detail",
+            kwargs={
+                "database_name": self.kwargs["database_name"],
+                "table_name": self.kwargs["table_name"],
+            },
+        )
+
 
 class GrantTableAccessView(OIDCLoginRequiredMixin, TableAccessMixin, BreadcrumbsMixin, CreateView):
     template_name = "database_access/database/grant_access.html"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: analytical-platform-ui
 description: Analytical Platform UI
 type: application
-version: 0.2.5
-appVersion: 0.2.5
+version: 0.2.6
+appVersion: 0.2.6
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/4/4a/Ministry_of_Justice_logo_%28United_Kingdom%29.svg/611px-Ministry_of_Justice_logo_%28United_Kingdom%29.svg.png
 maintainers:
   - name: moj-data-platform-robot


### PR DESCRIPTION
- Allow revoking an opt-in which does not exist to continue
- Allow granting an opt-in which already exists to continue
- This fixes bugs when there the state of the DB and LF gets out of sync

There is now quite a lot of repetition of the error handling when an `InvalidInputException` is returned between a number of actions, I'll refactor this in a future PR. But this should fix the immediate bug occurring in the dev environment.