### PR TITLE
Revert "Attempt to add dependabot groups for uv deps"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,11 +37,3 @@ updates:
     commit-message:
       prefix: ":dependabot: uv"
       include: "scope"
-    groups:
-      development-dependencies:
-        dependency-type: "development"
-      production-dependencies:
-        dependency-type: "production"
-        update-types:
-          - "minor"
-          - "patch"


### PR DESCRIPTION
Fixes #

## Proposed Changes

- Reverts ministryofjustice/analytical-platform-ui#522, because it did all `uv` deps 😢 

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>