### PR TITLE
🔀 Switch to Make for CI/CD testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,21 +27,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Build Image
-        id: build_image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
-        with:
-          file: Dockerfile
-          push: false
-          load: true
-          tags: ghcr.io/${{ github.repository }}:${{ github.sha }}
-          build-args: |
-            BUILD_DEV=true
-
       - name: Run Python Tests
         id: run_python_tests
         run: |
-          docker compose --file contrib/docker-compose-test.yml run --rm interfaces
+          make test
         env:
           NETWORK: default
           CONTAINER_IMAGE_NAME: ghcr.io/${{ github.repository }}

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ serve-sso:
 
 container-build:
 	@echo "Building container image $(CONTAINER_IMAGE_NAME):$(CONTAINER_IMAGE_TAG)"
-	docker build --platform linux/amd64 --file Dockerfile --tag $(CONTAINER_IMAGE_NAME):$(CONTAINER_IMAGE_TAG) .
+	docker build --platform linux/amd64 --file Dockerfile --build-arg BUILD_DEV="true" --tag $(CONTAINER_IMAGE_NAME):$(CONTAINER_IMAGE_TAG) .
 
 container-test: container-build
 	@echo "Testing container image $(CONTAINER_IMAGE_NAME):$(CONTAINER_IMAGE_TAG)"

--- a/contrib/docker-compose-test.yml
+++ b/contrib/docker-compose-test.yml
@@ -1,6 +1,6 @@
 ---
 services:
-  db:
+  postgres:
     extends:
       file: docker-compose-postgres.yml
       service: postgres
@@ -9,12 +9,12 @@ services:
     image: "${CONTAINER_IMAGE_NAME}:${CONTAINER_IMAGE_TAG}"
     ports: ["8000:8000"]
     depends_on:
-      db:
+      postgres:
         condition: service_healthy
-    links: [db]
+    links: [postgres]
     environment:
       ALLOWED_HOSTS: "localhost 127.0.0.1 0.0.0.0"
-      DB_HOST: "db"
+      DB_HOST: "postgres"
       DB_NAME: ap
       DB_PASSWORD: ap
       DB_PORT: 5432


### PR DESCRIPTION
## Proposed Changes

- Fixes a bug for running containerised testing locally
- Switches `.github/workflows/test.yml` to use Make's `test` command [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself)

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>