### PR TITLE
Fix settings import in urls.py

### DIFF
--- a/ap/urls.py
+++ b/ap/urls.py
@@ -1,7 +1,6 @@
+from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path
-
-from ap import settings
 
 from . import views
 


### PR DESCRIPTION
Settings were being directly imported, which meant that locally `DEBUG` was always read from the common settings file, causing an error when trying to run the server locally