### PR TITLE
Update dev container postgres version to 17

### DIFF
--- a/.devcontainer/features/src/postgresql/install.sh
+++ b/.devcontainer/features/src/postgresql/install.sh
@@ -9,6 +9,6 @@ apt-get update
 apt-get -y install \
   postgresql-common \
   postgresql-client-common \
-  postgresql-15 \
-  postgresql-client-15 \
+  postgresql-17 \
+  postgresql-client-17 \
   libpq-dev


### PR DESCRIPTION
Postgres version was updated in an earlier commit, but the dev container feature was missed off.

If you have run the dev container locally previously, you may need to run the following command to kill off old volumes:

```
docker compose --file contrib/docker-compose-postgres.yml down -v
```

Then rebuild the dev container.